### PR TITLE
Settings: Privacy Guard: Fix missing background tab

### DIFF
--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -37,6 +37,7 @@
         <item>@string/app_ops_categories_messaging</item>
         <item>@string/app_ops_categories_media</item>
         <item>@string/app_ops_categories_device</item>
+        <item>@string/app_ops_categories_background</item>
         <item>@string/app_ops_categories_bootup</item>
         <item>@string/app_ops_categories_su</item>
     </string-array>

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -62,6 +62,7 @@
     <string name="app_ops_categories_messaging">Messaging</string>
     <string name="app_ops_categories_media">Media</string>
     <string name="app_ops_categories_device">Device</string>
+    <string name="app_ops_categories_background">Background</string>
     <string name="app_ops_categories_bootup">Bootup</string>
     <string name="app_ops_categories_su">Superuser</string>
 


### PR DESCRIPTION
 * Changes introduced in Android 7.0 added a new UI
    to control the apps running in background,
    adding our tabs created an offset of 1 that breaks
    the bootup and superuser list content links

 * Add the invisible tab to its categories location
    and allow the CM tabs to be listed properly

 * Reference: f467c0acacd834257189dd73f260939a742114f9

Change-Id: Iacecc532592490e708b97189f28fba79b09b7235